### PR TITLE
Correct cable routing cost estimation and add regression test

### DIFF
--- a/economic_model.py
+++ b/economic_model.py
@@ -65,10 +65,13 @@ class WECEconomicModel:
         total_cable_length = 0
         
         # Minimum spanning tree approximation
-        # For simplicity, use average distance * n_wecs as approximation
+        # Use average pairwise distance scaled by (n_wecs - 1) to represent
+        # the number of connections in a spanning tree. Previously this used
+        # ``n_wecs`` which effectively assumed an extra cable run and
+        # overestimated costs, especially for small farms.
         if len(distances) > 0:
             avg_distance = np.mean(distances)
-            total_cable_length = avg_distance * n_wecs * 0.8  # 80% efficiency factor
+            total_cable_length = avg_distance * max(n_wecs - 1, 0) * 0.8  # 80% efficiency factor
         
         # Add connection to shore (distance to centroid)
         centroid = np.mean(positions, axis=0)

--- a/test_cable_costs.py
+++ b/test_cable_costs.py
@@ -1,0 +1,10 @@
+import numpy as np
+from economic_model import WECEconomicModel
+
+def test_cable_costs_two_wecs():
+    model = WECEconomicModel()
+    coords = np.array([0.0, 0.0, 100.0, 0.0])  # two WECs 100m apart
+    cost = model.calculate_cable_costs(coords, n_wecs=2)
+    expected_length = 100 * 0.8 + 50  # MST length + shore connection
+    expected_cost = expected_length * model.cable_cost_per_meter
+    assert np.isclose(cost, expected_cost)


### PR DESCRIPTION
## Summary
- fix cable routing cost estimation to use (n_wecs - 1) spanning tree connections
- add regression test verifying cable cost for two WEC layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c08449088330ad104093f480d0a6